### PR TITLE
DomainExceptionのプロパティ名変更

### DIFF
--- a/src/Application/Model/ExceptionModel.cs
+++ b/src/Application/Model/ExceptionModel.cs
@@ -53,11 +53,11 @@ namespace Application.Model
       }
       else
       {
-        // ドメインレイヤー用例外の場合はIDからメッセージを取得する
+        // ドメインレイヤー用例外の場合はメッセージを取得する
         var result = new StringBuilder();
-        foreach (var item in domainException.MessageIds)
+        foreach (var message in domainException.Messages)
         {
-          result.AppendLine(GetDomainMessage(item));
+          result.AppendLine(GetDomainMessage(message));
         }
         return result.ToString();
       }
@@ -66,22 +66,22 @@ namespace Application.Model
     /// <summary>
     /// 例外メッセージを返す
     /// </summary>
-    /// <param name="targetAndMessageID">対象項目とメッセージIDの文字列</param>
+    /// <param name="message">対象項目とメッセージIDの文字列</param>
     /// <returns>例外メッセージ</returns>
-    private string GetDomainMessage(DomainExceptionMessage targetAndMessageID)
+    private string GetDomainMessage(DomainExceptionMessage message)
     {
-      switch (targetAndMessageID.MessageID)
+      switch (message.MessageID)
       {
         case DomainExceptionMessage.ExceptionType.Empty:
-          return $"Empty: {targetAndMessageID.Target}";
+          return $"Empty: {message.Target}";
         case DomainExceptionMessage.ExceptionType.DBError:
-          return $"DBError: {targetAndMessageID.Target}";
+          return $"DBError: {message.Target}";
         case DomainExceptionMessage.ExceptionType.ParameterError:
-          return $"parameterError: {targetAndMessageID.Target}";
+          return $"parameterError: {message.Target}";
         case DomainExceptionMessage.ExceptionType.FileOutputError:
-          return $"OutputFileError: {targetAndMessageID.Target}";
+          return $"OutputFileError: {message.Target}";
         default:
-          return $"UnknownError: {targetAndMessageID.Target}";
+          return $"UnknownError: {message.Target}";
       }
     }
   }

--- a/src/Domain/Exceptions/DomainException.cs
+++ b/src/Domain/Exceptions/DomainException.cs
@@ -9,12 +9,6 @@ namespace Domain.Exceptions
   public class DomainException : Exception
   {
     /// <summary>
-    /// メッセージIDリスト
-    /// </summary>
-    [Obsolete]
-    public ReadOnlyCollection<DomainExceptionMessage> MessageIds { get; private set; }
-
-    /// <summary>
     /// メッセージリスト
     /// </summary>
     public ReadOnlyCollection<DomainExceptionMessage> Messages { get; private set; }
@@ -22,24 +16,22 @@ namespace Domain.Exceptions
     /// <summary>
     /// コンストラクタ
     /// </summary>
-    /// <param name="messageIds">メッセージIDリスト</param>
+    /// <param name="messages">メッセージリスト</param>
     /// <remarks>Presentationで補足する場合はApplicationのExceptionModelを利用する</remarks>
-    public DomainException(ReadOnlyCollection<DomainExceptionMessage> messageIds)
+    public DomainException(ReadOnlyCollection<DomainExceptionMessage> messages)
     {
-      MessageIds = messageIds;
-      Messages = messageIds;
+      Messages = messages;
     }
 
     /// <summary>
     /// コンストラクタ
     /// </summary>
-    /// <param name="messageIds">メッセージIDリスト</param>
+    /// <param name="messages">メッセージリスト</param>
     /// <param name="innerException">内部例外エラー</param>
     /// <remarks>Presentationで補足する場合はApplicationのExceptionModelを利用する</remarks>
-    public DomainException(ReadOnlyCollection<DomainExceptionMessage> messageIds,Exception innerException):base(innerException.Message)
+    public DomainException(ReadOnlyCollection<DomainExceptionMessage> messages, Exception innerException) : base(innerException.Message)
     {
-      MessageIds = messageIds;
-      Messages = messageIds;
+      Messages = messages;
     }
   }
 }

--- a/src/Domain/Exceptions/DomainException.cs
+++ b/src/Domain/Exceptions/DomainException.cs
@@ -11,6 +11,7 @@ namespace Domain.Exceptions
     /// <summary>
     /// メッセージIDリスト
     /// </summary>
+    [Obsolete]
     public ReadOnlyCollection<DomainExceptionMessage> MessageIds { get; private set; }
 
     /// <summary>

--- a/src/Domain/Exceptions/DomainException.cs
+++ b/src/Domain/Exceptions/DomainException.cs
@@ -14,6 +14,11 @@ namespace Domain.Exceptions
     public ReadOnlyCollection<DomainExceptionMessage> MessageIds { get; private set; }
 
     /// <summary>
+    /// メッセージリスト
+    /// </summary>
+    public ReadOnlyCollection<DomainExceptionMessage> Messages { get; private set; }
+
+    /// <summary>
     /// コンストラクタ
     /// </summary>
     /// <param name="messageIds">メッセージIDリスト</param>
@@ -21,6 +26,7 @@ namespace Domain.Exceptions
     public DomainException(ReadOnlyCollection<DomainExceptionMessage> messageIds)
     {
       MessageIds = messageIds;
+      Messages = messageIds;
     }
 
     /// <summary>
@@ -32,6 +38,7 @@ namespace Domain.Exceptions
     public DomainException(ReadOnlyCollection<DomainExceptionMessage> messageIds,Exception innerException):base(innerException.Message)
     {
       MessageIds = messageIds;
+      Messages = messageIds;
     }
   }
 }

--- a/src/PostgreSQL2DTOTest/ApplicationTest/TestGenerateCSApplicationService.cs
+++ b/src/PostgreSQL2DTOTest/ApplicationTest/TestGenerateCSApplicationService.cs
@@ -37,9 +37,9 @@ namespace PostgreSQL2DTOTest.ApplicationTest
     public void ExceptionParamNull()
     {
       var ex = Assert.ThrowsAny<DomainException>(() => applicationService.GenerateCSFileFromDB(null));
-      Assert.Single(ex.MessageIds);
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[0].MessageID);
-      Assert.Equal("inputParamModel[]", ex.MessageIds[0].Target);
+      Assert.Single(ex.Messages);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal("inputParamModel[]", ex.Messages[0].Target);
     }
 
     [Fact]

--- a/src/PostgreSQL2DTOTest/DomainTest/CSFiles/TestFileDataEntity.cs
+++ b/src/PostgreSQL2DTOTest/DomainTest/CSFiles/TestFileDataEntity.cs
@@ -1,5 +1,6 @@
-using Domain.CSFiles;
 using Domain.Exceptions;
+using Domain.CSFiles;
+using System.Collections.Generic;
 using System;
 using Xunit;
 
@@ -31,13 +32,13 @@ namespace PostgreSQL2DTOTest.Domain.CSFiles
       string nameSpace = null;
 
       var ex = Assert.ThrowsAny<DomainException>(() => FileDataEntity.Create(outputPath, nameSpace));
-      Assert.Equal(2, ex.MessageIds.Count);
+      Assert.Equal(2, ex.Messages.Count);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[0].MessageID);
-      Assert.Equal("outputPath[]", ex.MessageIds[0].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal("outputPath[]", ex.Messages[0].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[1].MessageID);
-      Assert.Equal("nameSpace[]", ex.MessageIds[1].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[1].MessageID);
+      Assert.Equal("nameSpace[]", ex.Messages[1].Target);
     }
 
     [Fact]
@@ -47,10 +48,10 @@ namespace PostgreSQL2DTOTest.Domain.CSFiles
       string nameSpace = "NameSpace";
 
       var ex = Assert.ThrowsAny<DomainException>(() => FileDataEntity.Create(outputPath, nameSpace));
-      Assert.Single(ex.MessageIds);
+      Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[0].MessageID);
-      Assert.Equal("outputPath[]", ex.MessageIds[0].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal("outputPath[]", ex.Messages[0].Target);
     }
 
     [Fact]
@@ -60,10 +61,10 @@ namespace PostgreSQL2DTOTest.Domain.CSFiles
       string nameSpace = null;
 
       var ex = Assert.ThrowsAny<DomainException>(() => FileDataEntity.Create(outputPath, nameSpace));
-      Assert.Single(ex.MessageIds);
+      Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[0].MessageID);
-      Assert.Equal("nameSpace[]", ex.MessageIds[0].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal("nameSpace[]", ex.Messages[0].Target);
     }
 
     [Fact]

--- a/src/PostgreSQL2DTOTest/DomainTest/Classes/TestClassEntity.cs
+++ b/src/PostgreSQL2DTOTest/DomainTest/Classes/TestClassEntity.cs
@@ -1,10 +1,10 @@
 using Domain.Classes;
-using Domain.DB;
 using Domain.Exceptions;
+using Domain.DB;
 using PostgreSQL2DTOTest.Shared;
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 using Xunit;
 
 namespace PostgreSQL2DTOTest.Domain.Classes
@@ -36,7 +36,7 @@ namespace PostgreSQL2DTOTest.Domain.Classes
     {
       var mockDBRepository = new MockDBRepository();
       var entities = mockDBRepository.GetClasses(DBParameterEntity.Create("HostName", "UserID", "Password", "Database", 0));
-      return entities.Where(entity => entity.Name == "m_test").FirstOrDefault()?.Properties.ToList();
+      return entities.Where(entity => entity.Name=="m_test").FirstOrDefault()?.Properties.ToList();
     }
 
     [Fact]
@@ -47,16 +47,16 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var properties = new List<PropertyEntity>();
 
       var ex = Assert.ThrowsAny<DomainException>(() => ClassEntity.Create(name, comment, properties.AsReadOnly()));
-      Assert.Equal(3, ex.MessageIds.Count);
+      Assert.Equal(3, ex.Messages.Count);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[0].MessageID);
-      Assert.Equal("name[]", ex.MessageIds[0].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal("name[]", ex.Messages[0].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[1].MessageID);
-      Assert.Equal("comment[]", ex.MessageIds[1].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[1].MessageID);
+      Assert.Equal("comment[]", ex.Messages[1].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[2].MessageID);
-      Assert.Equal($"properties[{properties.AsReadOnly()}]", ex.MessageIds[2].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[2].MessageID);
+      Assert.Equal($"properties[{properties.AsReadOnly()}]", ex.Messages[2].Target);
     }
 
     [Fact]
@@ -67,10 +67,10 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var properties = GetMockProperty();
 
       var ex = Assert.ThrowsAny<DomainException>(() => ClassEntity.Create(name, comment, properties.AsReadOnly()));
-      Assert.Single(ex.MessageIds);
+      Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[0].MessageID);
-      Assert.Equal("name[]", ex.MessageIds[0].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal("name[]", ex.Messages[0].Target);
     }
 
     [Fact]
@@ -81,10 +81,10 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var properties = GetMockProperty();
 
       var ex = Assert.ThrowsAny<DomainException>(() => ClassEntity.Create(name, comment, properties.AsReadOnly()));
-      Assert.Single(ex.MessageIds);
+      Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[0].MessageID);
-      Assert.Equal("comment[]", ex.MessageIds[0].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal("comment[]", ex.Messages[0].Target);
     }
 
     [Fact]
@@ -95,10 +95,10 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var properties = new List<PropertyEntity>();
 
       var ex = Assert.ThrowsAny<DomainException>(() => ClassEntity.Create(name, comment, properties.AsReadOnly()));
-      Assert.Single(ex.MessageIds);
+      Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[0].MessageID);
-      Assert.Equal($"properties[{properties.AsReadOnly()}]", ex.MessageIds[0].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal($"properties[{properties.AsReadOnly()}]", ex.Messages[0].Target);
     }
 
     [Fact]

--- a/src/PostgreSQL2DTOTest/DomainTest/Classes/TestPropertyEntity.cs
+++ b/src/PostgreSQL2DTOTest/DomainTest/Classes/TestPropertyEntity.cs
@@ -33,16 +33,16 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       string comment = null;
 
       var ex = Assert.ThrowsAny<DomainException>(() => PropertyEntity.Create(name, typeName, comment));
-      Assert.Equal(3, ex.MessageIds.Count);
+      Assert.Equal(3, ex.Messages.Count);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[0].MessageID);
-      Assert.Equal("name[]", ex.MessageIds[0].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal("name[]", ex.Messages[0].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[1].MessageID);
-      Assert.Equal("typeName[]", ex.MessageIds[1].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[1].MessageID);
+      Assert.Equal("typeName[]", ex.Messages[1].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[2].MessageID);
-      Assert.Equal("comment[]", ex.MessageIds[2].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[2].MessageID);
+      Assert.Equal("comment[]", ex.Messages[2].Target);
     }
 
     [Fact]
@@ -53,10 +53,10 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       string comment = "コメント";
 
       var ex = Assert.ThrowsAny<DomainException>(() => PropertyEntity.Create(name, typeName, comment));
-      Assert.Single(ex.MessageIds);
+      Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[0].MessageID);
-      Assert.Equal("name[]", ex.MessageIds[0].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal("name[]", ex.Messages[0].Target);
     }
 
     [Fact]
@@ -67,10 +67,10 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       string comment = "コメント";
 
       var ex = Assert.ThrowsAny<DomainException>(() => PropertyEntity.Create(name, typeName, comment));
-      Assert.Single(ex.MessageIds);
+      Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[0].MessageID);
-      Assert.Equal("typeName[]", ex.MessageIds[0].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal("typeName[]", ex.Messages[0].Target);
     }
 
     [Fact]
@@ -81,10 +81,10 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       string comment = null;
 
       var ex = Assert.ThrowsAny<DomainException>(() => PropertyEntity.Create(name, typeName, comment));
-      Assert.Single(ex.MessageIds);
+      Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[0].MessageID);
-      Assert.Equal("comment[]", ex.MessageIds[0].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal("comment[]", ex.Messages[0].Target);
     }
 
     [Fact]

--- a/src/PostgreSQL2DTOTest/DomainTest/DB/TestDBParameterEntity.cs
+++ b/src/PostgreSQL2DTOTest/DomainTest/DB/TestDBParameterEntity.cs
@@ -1,5 +1,6 @@
 using Domain.DB;
 using Domain.Exceptions;
+using System.Collections.Generic;
 using System;
 using Xunit;
 
@@ -34,22 +35,22 @@ namespace PostgreSQL2DTOTest.Domain.DB
       int? port = null;
 
       var ex = Assert.ThrowsAny<DomainException>(() => DBParameterEntity.Create(hostName, userID, password, database, port));
-      Assert.Equal(5, ex.MessageIds.Count);
+      Assert.Equal(5, ex.Messages.Count);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[0].MessageID);
-      Assert.Equal("hostName[]", ex.MessageIds[0].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal("hostName[]", ex.Messages[0].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[1].MessageID);
-      Assert.Equal("userID[]", ex.MessageIds[1].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[1].MessageID);
+      Assert.Equal("userID[]", ex.Messages[1].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[2].MessageID);
-      Assert.Equal("password[]", ex.MessageIds[2].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[2].MessageID);
+      Assert.Equal("password[]", ex.Messages[2].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[3].MessageID);
-      Assert.Equal("database[]", ex.MessageIds[3].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[3].MessageID);
+      Assert.Equal("database[]", ex.Messages[3].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[4].MessageID);
-      Assert.Equal("port[]", ex.MessageIds[4].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[4].MessageID);
+      Assert.Equal("port[]", ex.Messages[4].Target);
     }
 
     [Fact]
@@ -62,10 +63,10 @@ namespace PostgreSQL2DTOTest.Domain.DB
       int? port = 0;
 
       var ex = Assert.ThrowsAny<DomainException>(() => DBParameterEntity.Create(hostName, userID, password, database, port));
-      Assert.Single(ex.MessageIds);
+      Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[0].MessageID);
-      Assert.Equal("hostName[]", ex.MessageIds[0].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal("hostName[]", ex.Messages[0].Target);
     }
 
     [Fact]
@@ -78,10 +79,10 @@ namespace PostgreSQL2DTOTest.Domain.DB
       int? port = 0;
 
       var ex = Assert.ThrowsAny<DomainException>(() => DBParameterEntity.Create(hostName, userID, password, database, port));
-      Assert.Single(ex.MessageIds);
+      Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[0].MessageID);
-      Assert.Equal("userID[]", ex.MessageIds[0].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal("userID[]", ex.Messages[0].Target);
     }
 
     [Fact]
@@ -94,10 +95,10 @@ namespace PostgreSQL2DTOTest.Domain.DB
       int? port = 0;
 
       var ex = Assert.ThrowsAny<DomainException>(() => DBParameterEntity.Create(hostName, userID, password, database, port));
-      Assert.Single(ex.MessageIds);
+      Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[0].MessageID);
-      Assert.Equal("password[]", ex.MessageIds[0].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal("password[]", ex.Messages[0].Target);
     }
 
     [Fact]
@@ -110,10 +111,10 @@ namespace PostgreSQL2DTOTest.Domain.DB
       int? port = 0;
 
       var ex = Assert.ThrowsAny<DomainException>(() => DBParameterEntity.Create(hostName, userID, password, database, port));
-      Assert.Single(ex.MessageIds);
+      Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[0].MessageID);
-      Assert.Equal("database[]", ex.MessageIds[0].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal("database[]", ex.Messages[0].Target);
     }
 
     [Fact]
@@ -126,10 +127,10 @@ namespace PostgreSQL2DTOTest.Domain.DB
       int? port = null;
 
       var ex = Assert.ThrowsAny<DomainException>(() => DBParameterEntity.Create(hostName, userID, password, database, port));
-      Assert.Single(ex.MessageIds);
+      Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.MessageIds[0].MessageID);
-      Assert.Equal("port[]", ex.MessageIds[0].Target);
+      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal("port[]", ex.Messages[0].Target);
     }
 
     [Fact]

--- a/src/PostgreSQL2DTOTest/InfrastructureTest/TestCSFileRepository.cs
+++ b/src/PostgreSQL2DTOTest/InfrastructureTest/TestCSFileRepository.cs
@@ -47,7 +47,7 @@ namespace PostgreSQL2DTOTest.InfrastructureTest
       FileDataEntity fileDataEntity = null;
 
       var ex = Assert.ThrowsAny<DomainException>(() => repository.Generate(classEntities, fileDataEntity));
-      Assert.Equal(2, ex.MessageIds.Count);
+      Assert.Equal(2, ex.Messages.Count);
     }
 
     [Fact, Trait("Category", "InfrastructureTest")]
@@ -57,7 +57,7 @@ namespace PostgreSQL2DTOTest.InfrastructureTest
       var fileDataEntity = FileDataEntity.Create("DB.Dto", "CSOutputs");
 
       var ex = Assert.ThrowsAny<DomainException>(() => repository.Generate(classEntities, fileDataEntity));
-      Assert.Single(ex.MessageIds);
+      Assert.Single(ex.Messages);
     }
 
     [Fact, Trait("Category", "InfrastructureTest")]
@@ -68,7 +68,7 @@ namespace PostgreSQL2DTOTest.InfrastructureTest
       FileDataEntity fileDataEntity = null;
 
       var ex = Assert.ThrowsAny<DomainException>(() => repository.Generate(classEntities, fileDataEntity));
-      Assert.Single(ex.MessageIds);
+      Assert.Single(ex.Messages);
     }
 
     [Fact, Trait("Category", "InfrastructureTest")]


### PR DESCRIPTION
DomainExceptionMessageリストのプロパティ名を
「MessageIds」から「Messages」に変更した。