### PR TITLE
「出力先フォルダの存在確認と作成処理を追加」によるビルドエラーの解消

### DIFF
--- a/src/NET6/Infrastructure/CSFiles/CSFileRepository.cs
+++ b/src/NET6/Infrastructure/CSFiles/CSFileRepository.cs
@@ -20,9 +20,8 @@ namespace Infrastructure.CSFiles
     /// </summary>
     /// <param name="classEntities">出力対象のクラスエンティティリスト</param>
     /// <param name="fileDataEntity">出力情報</param>
-    /// <param name="useSnakeCase">スネークケースのままとするか</param>
     /// <returns>出力ファイル名リスト</returns>
-    public ReadOnlyCollection<string> Generate(List<ClassEntity> classEntities, FileDataEntity fileDataEntity, bool useSnakeCase)
+    public ReadOnlyCollection<string> Generate(List<ClassEntity> classEntities, FileDataEntity fileDataEntity)
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
@@ -41,13 +40,13 @@ namespace Infrastructure.CSFiles
             Directory.CreateDirectory(fileDataEntity.OutputPath);
           }
 
-          var createCS = new CreateCS(classEntity, fileDataEntity.NameSpace, useSnakeCase);
+          var createCS = new CreateCS(classEntity, fileDataEntity.NameSpace);
           var filePath = Path.Combine(fileDataEntity.OutputPath, createCS.FileName);
 
           // ファイル出力
           var message = new StringBuilder();
           message.Append($"  >>{classEntity.Name}... ");
-          CreateFile(createCS, filePath, fileDataEntity.NameSpace, useSnakeCase);
+          CreateFile(createCS, filePath, fileDataEntity.NameSpace);
           message.AppendLine("finish");
 
           result.Add(message.ToString());
@@ -69,8 +68,7 @@ namespace Infrastructure.CSFiles
     /// <param name="createCS">C#ソースコード生成クラス</param>
     /// <param name="filePath">C#ファイルパス</param>
     /// <param name="nameSpace">名前空間</param>
-    /// <param name="useSnakeCase">スネークケースのままとするか</param>
-    private void CreateFile(CreateCS createCS, string filePath, string nameSpace, bool useSnakeCase)
+    private void CreateFile(CreateCS createCS, string filePath, string nameSpace)
     {
       var csSource = ((ITransformText)createCS).TransformText();
 


### PR DESCRIPTION
「出力先フォルダの存在確認と作成処理を追加 #24」の実装時に
拙作(SQLite2DTO)[https://github.com/kazenetu/SQLite2DTO]を流用したが
一部ファイルで別機能が実装されていた。
修正を実施した。
