### PR TITLE
数値以降はキャメルケースにしないモードを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,15 @@ PostgreSQLのテーブル情報を取得し、C#のDTOクラスを作成する�
     dotnet runで実行する。  
     ```sh
     -- .NET6
-    dotnet run --project ./src/NET6/Presentation/ConsoleApp/ConsoleApp.csproj [NameSpace] [ファイル出力先] [DBサーバー(サーバ名やIPアドレス))] [ユーザーID] [パスワード] [データベース名] [ポート番号(省略可)]
+    dotnet run --project ./src/NET6/Presentation/ConsoleApp/ConsoleApp.csproj [NameSpace] [ファイル出力先] [DBサーバー(サーバ名やIPアドレス))] [ユーザーID] [パスワード] [データベース名] [ポート番号(省略可)]  ['useSnakeCase']
 
     -- .NET5
-    dotnet run --project ./src/NET5/Presentation/ConsoleApp/ConsoleApp.csproj [NameSpace] [ファイル出力先] [DBサーバー(サーバ名やIPアドレス))] [ユーザーID] [パスワード] [データベース名] [ポート番号(省略可)]    ```  
-    ※具体的な内容は「Dockerコンテナでの実行」を参照
+    dotnet run --project ./src/NET5/Presentation/ConsoleApp/ConsoleApp.csproj [NameSpace] [ファイル出力先] [DBサーバー(サーバ名やIPアドレス))] [ユーザーID] [パスワード] [データベース名] [ポート番号(省略可)]  ['useSnakeCase']    
+    ```  
+    ※DB接続の具体的な内容は「Dockerコンテナでの実行」を参照
+
+    ※「useSnakeCase」を入れると数値以降はテーブルの名称のままとなる。  
+    　テーブルカラム「abc_ef_**1_1**」→プロパティ「AbcEf**1_1**」
 
 * Dockerコンテナでの実行  
     Dockerコンテナ上で開発環境を構築する。  

--- a/README.md
+++ b/README.md
@@ -10,18 +10,28 @@ PostgreSQLのテーブル情報を取得し、C#のDTOクラスを作成する�
 
 ## 実行方法
 * ローカル実行  
-    dotnet runで実行する。  
-    ```sh
-    -- .NET6
-    dotnet run --project ./src/NET6/Presentation/ConsoleApp/ConsoleApp.csproj [NameSpace] [ファイル出力先] [DBサーバー(サーバ名やIPアドレス))] [ユーザーID] [パスワード] [データベース名] [ポート番号(省略可)]  ['useSnakeCase']
+  1. ビルド(初回のみ)  
+      T4テンプレート利用のため、初回のみビルドする。 
+      ```sh
+      -- .NET6
+      dotnet build ./src/NET6/Presentation/ConsoleApp/ConsoleApp.csproj
 
-    -- .NET5
-    dotnet run --project ./src/NET5/Presentation/ConsoleApp/ConsoleApp.csproj [NameSpace] [ファイル出力先] [DBサーバー(サーバ名やIPアドレス))] [ユーザーID] [パスワード] [データベース名] [ポート番号(省略可)]  ['useSnakeCase']    
-    ```  
-    ※DB接続の具体的な内容は「Dockerコンテナでの実行」を参照
+      -- .NET5
+      dotnet build ./src/NET5/Presentation/ConsoleApp/ConsoleApp.csproj
+      ```
 
-    ※「useSnakeCase」を入れると数値以降はテーブルの名称のままとなる。  
-    　テーブルカラム「abc_ef_**1_1**」→プロパティ「AbcEf**1_1**」
+   2. dotnet runを実行する。  
+      ```sh
+      -- .NET6
+      dotnet run --project ./src/NET6/Presentation/ConsoleApp/ConsoleApp.csproj [NameSpace] [ファイル出力先] [DBサーバー(サーバ名やIPアドレス))] [ユーザーID] [パスワード] [データベース名] [ポート番号(省略可)]  ['useSnakeCase']
+
+      -- .NET5
+      dotnet run --project ./src/NET5/Presentation/ConsoleApp/ConsoleApp.csproj [NameSpace] [ファイル出力先] [DBサーバー(サーバ名やIPアドレス))] [ユーザーID] [パスワード] [データベース名] [ポート番号(省略可)]  ['useSnakeCase']    
+      ```  
+      ※DB接続の具体的な内容は「Dockerコンテナでの実行」を参照
+
+      ※「useSnakeCase」を入れると数値以降はテーブルの名称のままとなる。  
+      　テーブルカラム「abc_ef_**1_1**」→プロパティ「AbcEf**1_1**」
 
 * Dockerコンテナでの実行  
     Dockerコンテナ上で開発環境を構築する。  
@@ -51,7 +61,16 @@ PostgreSQLのテーブル情報を取得し、C#のDTOクラスを作成する�
           ```
 
       1. コンテナ内で実行 
-          1. dotnet runで実行する。
+         1. ビルド(初回のみ)  
+              T4テンプレート利用のため、初回のみビルドする。 
+              ```sh
+              -- .NET6
+              dotnet build ./src/NET6/Presentation/ConsoleApp/ConsoleApp.csproj
+
+              -- .NET5
+              dotnet build ./src/NET5/Presentation/ConsoleApp/ConsoleApp.csproj
+              ```
+          1. dotnet runを実行する。
               ```sh
               --.NET6
               dotnet run --project ./src/NET6/Presentation/ConsoleApp/ConsoleApp.csproj DB.Dto CSOutputs postgresql_server test test testDB
@@ -84,8 +103,18 @@ DBリポジトリのテスト「TestDBRepository」ではPostgreSQLを利用す�
 
 ### テスト方法
 * ローカル実行  
+  * テスト前：ビルド(初回のみ)  
+      T4テンプレート利用のため、初回のみビルドする。 
+      ```sh
+      -- .NET6
+      dotnet build ./src/NET6/Presentation/ConsoleApp/ConsoleApp.csproj
+
+      -- .NET5
+      dotnet build ./src/NET5/Presentation/ConsoleApp/ConsoleApp.csproj
+      ```
+
    * すべて実行する場合  
-        dotnet runで実行する。  
+        テストを実行する。  
         ```sh
         --.NET6
         dotnet test ./src/NET6/PostgreSQL2DTOTest/PostgreSQL2DTOTest.csproj
@@ -95,7 +124,7 @@ DBリポジトリのテスト「TestDBRepository」ではPostgreSQLを利用す�
         ```  
 
    * DBアクセスなどインフラ層のテストを除外する場合  
-        dotnet runで実行する。  
+        filterオプションを付けてテストを実行する。  
         ```sh
         --.NET6
         dotnet test ./src/NET6/PostgreSQL2DTOTest/PostgreSQL2DTOTest.csproj --filter Category!=InfrastructureTest
@@ -132,6 +161,16 @@ DBリポジトリのテスト「TestDBRepository」ではPostgreSQLを利用す�
           ```
 
       1. コンテナ内で実行 
+         1. ビルド(初回のみ)  
+              T4テンプレート利用のため、初回のみビルドする。 
+              ```sh
+              -- .NET6
+              dotnet build ./src/NET6/Presentation/ConsoleApp/ConsoleApp.csproj
+
+              -- .NET5
+              dotnet build ./src/NET5/Presentation/ConsoleApp/ConsoleApp.csproj
+              ```
+
           1. テストを実行する。  
               ```sh
               --.NET6

--- a/src/NET6/Application/GenerateCSApplicationService.cs
+++ b/src/NET6/Application/GenerateCSApplicationService.cs
@@ -45,7 +45,7 @@ namespace Application
       if (exceptionMessages.Count > 0) throw new DomainException(exceptionMessages.AsReadOnly());
 
       var classes = dbRepository.GetClasses(DBParameterEntity.Create(inputParamModel.HostName, inputParamModel.UserID, inputParamModel.Password, inputParamModel.Database, inputParamModel.Port));
-      var messages = csFileRepository.Generate(classes, FileDataEntity.Create(inputParamModel.OutputPath, inputParamModel.NameSpace));
+      var messages = csFileRepository.Generate(classes, FileDataEntity.Create(inputParamModel.OutputPath, inputParamModel.NameSpace), inputParamModel.UseSnakeCase);
 
       return new GeneretedFileResultsModel(messages);
     }

--- a/src/NET6/Application/Model/InputParamModel.cs
+++ b/src/NET6/Application/Model/InputParamModel.cs
@@ -44,16 +44,22 @@ namespace Application.Model
     public int Port { get; private set; }
 
     /// <summary>
+    /// スネークケースのままとするか
+    /// </summary>
+    public bool UseSnakeCase { get; private set; }
+
+    /// <summary>
     /// コンストラクタ
     /// </summary>
     /// <param name="nameSpace">CSファイルのクラスに設定する名前空間</param>
     /// <param name="outputPath">出力先ディレクトリパス</param>
+    /// <param name="useSnakeCase">スネークケースのままとするか</param>
     /// <param name="hostName">サーバーホスト</param>
     /// <param name="userID">ユーザーID</param>
     /// <param name="password">パスワード</param>
     /// <param name="database">データベース名</param>
     /// <param name="port">ポート番号(初期値：5432)</param>
-    public InputParamModel(string nameSpace, string outputPath, string hostName, string userID, string password, string database, int? port)
+    public InputParamModel(string nameSpace, string outputPath, bool useSnakeCase, string hostName, string userID, string password, string database, int? port)
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
@@ -73,6 +79,7 @@ namespace Application.Model
       Password = password;
       Database = database;
       Port = port.Value;
+      UseSnakeCase = useSnakeCase;
     }
   }
 }

--- a/src/NET6/Domain/CSFiles/ICSFileRepository.cs
+++ b/src/NET6/Domain/CSFiles/ICSFileRepository.cs
@@ -14,7 +14,8 @@ namespace Domain.CSFiles
     /// </summary>
     /// <param name="classEntities">出力対象のクラスエンティティリスト</param>
     /// <param name="fileDataEntity">出力情報</param>
+    /// <param name="useSnakeCase">スネークケースのままとするか</param>
     /// <returns>出力ファイル名リスト</returns>
-    ReadOnlyCollection<string> Generate(List<ClassEntity> classEntities, FileDataEntity fileDataEntity);
+    ReadOnlyCollection<string> Generate(List<ClassEntity> classEntities, FileDataEntity fileDataEntity, bool useSnakeCase);
   }
 }

--- a/src/NET6/Infrastructure/CSFiles/CSFileRepository.cs
+++ b/src/NET6/Infrastructure/CSFiles/CSFileRepository.cs
@@ -20,8 +20,9 @@ namespace Infrastructure.CSFiles
     /// </summary>
     /// <param name="classEntities">出力対象のクラスエンティティリスト</param>
     /// <param name="fileDataEntity">出力情報</param>
+    /// <param name="useSnakeCase">スネークケースのままとするか</param>
     /// <returns>出力ファイル名リスト</returns>
-    public ReadOnlyCollection<string> Generate(List<ClassEntity> classEntities, FileDataEntity fileDataEntity)
+    public ReadOnlyCollection<string> Generate(List<ClassEntity> classEntities, FileDataEntity fileDataEntity, bool useSnakeCase)
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
@@ -40,13 +41,13 @@ namespace Infrastructure.CSFiles
             Directory.CreateDirectory(fileDataEntity.OutputPath);
           }
 
-          var createCS = new CreateCS(classEntity, fileDataEntity.NameSpace);
+          var createCS = new CreateCS(classEntity, fileDataEntity.NameSpace, useSnakeCase);
           var filePath = Path.Combine(fileDataEntity.OutputPath, createCS.FileName);
 
           // ファイル出力
           var message = new StringBuilder();
           message.Append($"  >>{classEntity.Name}... ");
-          CreateFile(createCS, filePath, fileDataEntity.NameSpace);
+          CreateFile(createCS, filePath, fileDataEntity.NameSpace, useSnakeCase);
           message.AppendLine("finish");
 
           result.Add(message.ToString());
@@ -68,7 +69,8 @@ namespace Infrastructure.CSFiles
     /// <param name="createCS">C#ソースコード生成クラス</param>
     /// <param name="filePath">C#ファイルパス</param>
     /// <param name="nameSpace">名前空間</param>
-    private void CreateFile(CreateCS createCS, string filePath, string nameSpace)
+    /// <param name="useSnakeCase">スネークケースのままとするか</param>
+    private void CreateFile(CreateCS createCS, string filePath, string nameSpace, bool useSnakeCase)
     {
       var csSource = ((ITransformText)createCS).TransformText();
 

--- a/src/NET6/Infrastructure/CSFiles/Templates/CreateCS.cs
+++ b/src/NET6/Infrastructure/CSFiles/Templates/CreateCS.cs
@@ -20,10 +20,12 @@ namespace Infrastructure.CSFiles.Templates
     /// </summary>
     /// <param name="classEntity">作成対象クラス情報</param>
     /// <param name="nameSpace">作成対象クラスのnamespace</param>
-    public CreateCS(ClassEntity classEntity, string nameSpace)
+    /// <param name="useSnakeCase">スネークケースのままとするか</param>
+    public CreateCS(ClassEntity classEntity, string nameSpace, bool useSnakeCase)
     {
       this.classEntity = classEntity;
       NameSpace = nameSpace;
+      UseSnakeCase = useSnakeCase;
     }
 
     /// <summary>
@@ -38,14 +40,31 @@ namespace Infrastructure.CSFiles.Templates
     public string FileName { get { return $"{GetCSName(classEntity.Name)}.cs"; } }
 
     /// <summary>
+    /// スネークケースのままとするか
+    /// </summary>
+    public bool UseSnakeCase { get; private set; }
+
+    /// <summary>
     /// テーブル名やカラム名からC#用名称を取得
     /// </summary>
     /// <param name="name">DBから取得したテーブル名やカラム名</param>
     /// <returns>C#用名称</returns>
     private string GetCSName(string name)
     {
-      var words = name.Split('_').Select(word => { return word.ToUpper()[0].ToString() + (word.Length >= 2 ? word.Substring(1).ToLower() : string.Empty); });
-      return string.Concat(words);
+      var camelCaseLength = name.Length;
+      if(UseSnakeCase)
+      {
+        camelCaseLength = name.IndexOfAny("0123456789".ToCharArray())+1;
+        if(camelCaseLength <= 0) 
+        camelCaseLength = name.Length;
+      }
+
+      var words = name.Substring(0, camelCaseLength).Split('_').Select(word => { return word.ToUpper()[0].ToString() + (word.Length >= 2 ? word.Substring(1).ToLower() : string.Empty); });
+      var result = string.Concat(words);
+      if(name.Length != camelCaseLength){
+        result += name.Substring(camelCaseLength);
+      }
+      return result;
     }
 
     /// <summary>

--- a/src/NET6/PostgreSQL2DTOTest/ApplicationTest/TestGenerateCSApplicationService.cs
+++ b/src/NET6/PostgreSQL2DTOTest/ApplicationTest/TestGenerateCSApplicationService.cs
@@ -45,7 +45,8 @@ namespace PostgreSQL2DTOTest.ApplicationTest
     [Fact]
     public void Success()
     {
-      var inputParamModel = new InputParamModel("nameSpace", "outputPath", "hostName", "userID", "password", "database", 0);
+      var useSnakeCase = false;
+      var inputParamModel = new InputParamModel("nameSpace", "outputPath", useSnakeCase, "hostName", "userID", "password", "database", 0);
       var generetedFileResultsModel = applicationService.GenerateCSFileFromDB(inputParamModel);
 
       Assert.Equal(2, generetedFileResultsModel.Messages.Count);

--- a/src/NET6/PostgreSQL2DTOTest/InfrastructureTest/TestCSFileRepository.cs
+++ b/src/NET6/PostgreSQL2DTOTest/InfrastructureTest/TestCSFileRepository.cs
@@ -44,9 +44,10 @@ namespace PostgreSQL2DTOTest.InfrastructureTest
     public void ExceptionAllNG()
     {
       var classEntities = new List<ClassEntity>();
+      var useSnakeCase = false;
       FileDataEntity fileDataEntity = null;
 
-      var ex = Assert.ThrowsAny<DomainException>(() => repository.Generate(classEntities, fileDataEntity));
+      var ex = Assert.ThrowsAny<DomainException>(() => repository.Generate(classEntities, fileDataEntity, useSnakeCase));
       Assert.Equal(2, ex.Messages.Count);
     }
 
@@ -55,8 +56,9 @@ namespace PostgreSQL2DTOTest.InfrastructureTest
     {
       var classEntities = new List<ClassEntity>();
       var fileDataEntity = FileDataEntity.Create("DB.Dto", "CSOutputs");
+      var useSnakeCase = false;
 
-      var ex = Assert.ThrowsAny<DomainException>(() => repository.Generate(classEntities, fileDataEntity));
+      var ex = Assert.ThrowsAny<DomainException>(() => repository.Generate(classEntities, fileDataEntity, useSnakeCase));
       Assert.Single(ex.Messages);
     }
 
@@ -65,9 +67,10 @@ namespace PostgreSQL2DTOTest.InfrastructureTest
     {
       var mockDBRepository = new MockDBRepository();
       var classEntities = mockDBRepository.GetClasses(DBParameterEntity.Create("HostName", "UserID", "Password", "Database", 0));
+      var useSnakeCase = false;
       FileDataEntity fileDataEntity = null;
 
-      var ex = Assert.ThrowsAny<DomainException>(() => repository.Generate(classEntities, fileDataEntity));
+      var ex = Assert.ThrowsAny<DomainException>(() => repository.Generate(classEntities, fileDataEntity, useSnakeCase));
       Assert.Single(ex.Messages);
     }
 
@@ -77,8 +80,9 @@ namespace PostgreSQL2DTOTest.InfrastructureTest
       var mockDBRepository = new MockDBRepository();
       var classEntities = mockDBRepository.GetClasses(DBParameterEntity.Create("HostName", "UserID", "Password", "Database", 0));
       var fileDataEntity = FileDataEntity.Create("CSOutputs", "DB.Dto");
+      var useSnakeCase = false;
 
-      var messages = repository.Generate(classEntities, fileDataEntity);
+      var messages = repository.Generate(classEntities, fileDataEntity, useSnakeCase);
       Assert.Equal(2, messages.Count);
       Assert.Equal($"  >>m_test... finish{Environment.NewLine}", messages[0]);
       Assert.Equal($"  >>t_test... finish{Environment.NewLine}", messages[1]);

--- a/src/NET6/PostgreSQL2DTOTest/Shared/MockCSFileRepository.cs
+++ b/src/NET6/PostgreSQL2DTOTest/Shared/MockCSFileRepository.cs
@@ -18,8 +18,9 @@ namespace PostgreSQL2DTOTest.Shared
     /// </summary>
     /// <param name="classEntities">出力対象のクラスエンティティリスト</param>
     /// <param name="fileDataEntity">出力情報</param>
+    /// <param name="useSnakeCase">スネークケースのままとするか</param>
     /// <returns>出力ファイル名リスト</returns>
-    public ReadOnlyCollection<string> Generate(List<ClassEntity> classEntities, FileDataEntity fileDataEntity)
+    public ReadOnlyCollection<string> Generate(List<ClassEntity> classEntities, FileDataEntity fileDataEntity, bool useSnakeCase)
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();

--- a/src/NET6/PostgreSQL2DTOTest/Shared/MockDBRepository.cs
+++ b/src/NET6/PostgreSQL2DTOTest/Shared/MockDBRepository.cs
@@ -65,8 +65,8 @@ namespace PostgreSQL2DTOTest.Shared
       Table tempTable = null;
 
       tempTable = new Table("m_test", "マスタテーブル");
-      tempTable.Columns.Add(new Column("int", "integer", "intになる"));
-      tempTable.Columns.Add(new Column("Date", "date", "Dateになる"));
+      tempTable.Columns.Add(new Column("int_1", "integer", "intになる"));
+      tempTable.Columns.Add(new Column("Date_1_1", "date", "Dateになる"));
       result.Add(tempTable);
 
       tempTable = new Table("t_test", "テストテーブル");

--- a/src/NET6/Presentation/ConsoleApp/Program.cs
+++ b/src/NET6/Presentation/ConsoleApp/Program.cs
@@ -11,7 +11,7 @@ namespace Presentation.ConsoleApp
       if (args.Length < 6)
       {
         Console.WriteLine();
-        Console.WriteLine("Input parameters! \"NameSpace OutputPath ServerName UserID Password DatabaseName [portNo]\"");
+        Console.WriteLine("Input parameters! \"NameSpace OutputPath ServerName UserID Password DatabaseName [portNo] ['useSnakeCase']\"");
         Console.WriteLine();
         return;
       }
@@ -27,15 +27,22 @@ namespace Presentation.ConsoleApp
       var password = args[4];
       var database = args[5];
       int port = 5432;
+      var useSnakeCase = false;
+
       if (args.Length > 6)
       {
         port = int.Parse(args[5]);
+      }
+      if(args.Length >= 7 && args[6] == "useSnakeCase")
+      {
+        useSnakeCase = true;
       }
 
       try
       {
         // Appication呼び出し
-        var inputParamModel = new InputParamModel(nameSpace, outputPath, hostName, userID, password, database, port);
+        useSnakeCase = true;
+        var inputParamModel = new InputParamModel(nameSpace, outputPath, useSnakeCase, hostName, userID, password, database, port);
         var messages = new GenerateCSApplicationService().GenerateCSFileFromDB(inputParamModel).Messages;
 
         // ファイル生成結果を取得


### PR DESCRIPTION
数値以降はDBの名称と同じにするモードを追加した。

T4テンプレートを利用しているため、
「初回のみビルド」の文言をREADMEに追記した。
