### PR TITLE
プロパティの初期化とRecordを適用

### DIFF
--- a/src/NET6/Application/GenerateCSApplicationService.cs
+++ b/src/NET6/Application/GenerateCSApplicationService.cs
@@ -41,7 +41,7 @@ namespace Application
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
-      if (inputParamModel is null) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(inputParamModel)}[{inputParamModel}]", DomainExceptionMessage.ExceptionType.Empty));
+      if (inputParamModel is null) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(inputParamModel)}[{inputParamModel}]", ExceptionType.Empty));
       if (exceptionMessages.Count > 0) throw new DomainException(exceptionMessages.AsReadOnly());
 
       var classes = dbRepository.GetClasses(DBParameterEntity.Create(inputParamModel.HostName, inputParamModel.UserID, inputParamModel.Password, inputParamModel.Database, inputParamModel.Port));

--- a/src/NET6/Application/Model/ExceptionModel.cs
+++ b/src/NET6/Application/Model/ExceptionModel.cs
@@ -72,13 +72,13 @@ namespace Application.Model
     {
       switch (message.MessageID)
       {
-        case DomainExceptionMessage.ExceptionType.Empty:
+        case ExceptionType.Empty:
           return $"Empty: {message.Target}";
-        case DomainExceptionMessage.ExceptionType.DBError:
+        case ExceptionType.DBError:
           return $"DBError: {message.Target}";
-        case DomainExceptionMessage.ExceptionType.ParameterError:
+        case ExceptionType.ParameterError:
           return $"parameterError: {message.Target}";
-        case DomainExceptionMessage.ExceptionType.FileOutputError:
+        case ExceptionType.FileOutputError:
           return $"OutputFileError: {message.Target}";
         default:
           return $"UnknownError: {message.Target}";

--- a/src/NET6/Application/Model/GeneretedFileResultsModel.cs
+++ b/src/NET6/Application/Model/GeneretedFileResultsModel.cs
@@ -5,20 +5,6 @@ namespace Application.Model
   /// <summary>
   /// 生成結果モデル
   /// </summary>
-  public class GeneretedFileResultsModel
-  {
-    /// <summary>
-    /// 生成結果メッセージ
-    /// </summary>
-    public ReadOnlyCollection<string> Messages { get; init; }
-
-    /// <summary>
-    /// コンストラクタ
-    /// </summary>
-    /// <param name="messages">生成結果メッセージ</param>
-    public GeneretedFileResultsModel(ReadOnlyCollection<string> messages)
-    {
-      Messages = messages;
-    }
-  }
+  /// <param name="Messages">生成結果メッセージ</param>
+  public record GeneretedFileResultsModel(ReadOnlyCollection<string> Messages);
 }

--- a/src/NET6/Application/Model/GeneretedFileResultsModel.cs
+++ b/src/NET6/Application/Model/GeneretedFileResultsModel.cs
@@ -10,7 +10,7 @@ namespace Application.Model
     /// <summary>
     /// 生成結果メッセージ
     /// </summary>
-    public ReadOnlyCollection<string> Messages { get; private set; }
+    public ReadOnlyCollection<string> Messages { get; init; }
 
     /// <summary>
     /// コンストラクタ

--- a/src/NET6/Application/Model/InputParamModel.cs
+++ b/src/NET6/Application/Model/InputParamModel.cs
@@ -11,42 +11,42 @@ namespace Application.Model
     /// <summary>
     /// CSファイルのクラスに設定する名前空間
     /// </summary>
-    public string NameSpace { get; private set; }
+    public string NameSpace { get; init; }
 
     /// <summary>
     /// CSファイル出力先ディレクトリパス
     /// </summary>
-    public string OutputPath { get; private set; }
+    public string OutputPath { get; init; }
 
     /// <summary>
     /// DB接続情報：ホスト名
     /// </summary>
-    public string HostName { get; private set; }
+    public string HostName { get; init; }
 
     /// <summary>
     /// DB接続情報：ユーザーID
     /// </summary>
-    public string UserID { get; private set; }
+    public string UserID { get; init; }
 
     /// <summary>
     /// DB接続情報：パスワード
     /// </summary>
-    public string Password { get; private set; }
+    public string Password { get; init; }
 
     /// <summary>
     /// DB接続情報：データベース名
     /// </summary>
-    public string Database { get; private set; }
+    public string Database { get; init; }
 
     /// <summary>
     /// DB接続情報：ポート番号
     /// </summary>
-    public int Port { get; private set; }
+    public int Port { get; init; }
 
     /// <summary>
     /// スネークケースのままとするか
     /// </summary>
-    public bool UseSnakeCase { get; private set; }
+    public bool UseSnakeCase { get; init; }
 
     /// <summary>
     /// コンストラクタ

--- a/src/NET6/Application/Model/InputParamModel.cs
+++ b/src/NET6/Application/Model/InputParamModel.cs
@@ -63,13 +63,13 @@ namespace Application.Model
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
-      if (string.IsNullOrEmpty(nameSpace)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(nameSpace)}[{nameSpace}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (string.IsNullOrEmpty(outputPath)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(outputPath)}[{outputPath}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (string.IsNullOrEmpty(hostName)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(hostName)}[{hostName}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (string.IsNullOrEmpty(userID)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(userID)}[{userID}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (string.IsNullOrEmpty(password)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(password)}[{password}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (string.IsNullOrEmpty(database)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(database)}[{database}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (!port.HasValue) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(port)}[{port}]", DomainExceptionMessage.ExceptionType.Empty));
+      if (string.IsNullOrEmpty(nameSpace)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(nameSpace)}[{nameSpace}]", ExceptionType.Empty));
+      if (string.IsNullOrEmpty(outputPath)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(outputPath)}[{outputPath}]", ExceptionType.Empty));
+      if (string.IsNullOrEmpty(hostName)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(hostName)}[{hostName}]", ExceptionType.Empty));
+      if (string.IsNullOrEmpty(userID)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(userID)}[{userID}]", ExceptionType.Empty));
+      if (string.IsNullOrEmpty(password)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(password)}[{password}]", ExceptionType.Empty));
+      if (string.IsNullOrEmpty(database)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(database)}[{database}]", ExceptionType.Empty));
+      if (!port.HasValue) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(port)}[{port}]", ExceptionType.Empty));
       if (exceptionMessages.Count > 0) throw new DomainException(exceptionMessages.AsReadOnly());
 
       NameSpace = nameSpace;

--- a/src/NET6/Domain/CSFiles/FileDataEntity.cs
+++ b/src/NET6/Domain/CSFiles/FileDataEntity.cs
@@ -11,12 +11,12 @@ namespace Domain.CSFiles
     /// <summary>
     /// 出力パス
     /// </summary>
-    public string OutputPath { get; private set; }
+    public string OutputPath { get; init; }
 
     /// <summary>
     /// 名前空間
     /// </summary>
-    public string NameSpace { get; private set; }
+    public string NameSpace { get; init; }
 
     /// <summary>
     /// 非公開コンストラクタ

--- a/src/NET6/Domain/CSFiles/FileDataEntity.cs
+++ b/src/NET6/Domain/CSFiles/FileDataEntity.cs
@@ -35,8 +35,8 @@ namespace Domain.CSFiles
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
-      if (string.IsNullOrEmpty(outputPath)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(outputPath)}[{outputPath}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (string.IsNullOrEmpty(nameSpace)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(nameSpace)}[{nameSpace}]", DomainExceptionMessage.ExceptionType.Empty));
+      if (string.IsNullOrEmpty(outputPath)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(outputPath)}[{outputPath}]", ExceptionType.Empty));
+      if (string.IsNullOrEmpty(nameSpace)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(nameSpace)}[{nameSpace}]", ExceptionType.Empty));
       if (exceptionMessages.Count > 0) throw new DomainException(exceptionMessages.AsReadOnly());
 
       return new FileDataEntity()

--- a/src/NET6/Domain/Classes/ClassEntity.cs
+++ b/src/NET6/Domain/Classes/ClassEntity.cs
@@ -13,19 +13,19 @@ namespace Domain.Classes
     /// 名称
     /// </summary>
     /// <value>プロパティ名</value>
-    public string Name { get; private set; }
+    public string Name { get;init; }
 
     /// <summary>
     /// コメント
     /// </summary>
     /// <value>コメント文字列</value>
-    public string Comment { get; private set; }
+    public string Comment { get; init; }
 
     /// <summary>
     /// プロパティリスト
     /// </summary>
     /// <returns>プロパティリスト</returns>
-    public ReadOnlyCollection<PropertyEntity> Properties { get; private set; }
+    public ReadOnlyCollection<PropertyEntity> Properties { get; init; }
 
     /// <summary>
     /// 非公開コンストラクタ

--- a/src/NET6/Domain/Classes/ClassEntity.cs
+++ b/src/NET6/Domain/Classes/ClassEntity.cs
@@ -45,9 +45,9 @@ namespace Domain.Classes
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
-      if (string.IsNullOrEmpty(name)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(name)}[{name}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (string.IsNullOrEmpty(comment)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(comment)}[{comment}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (properties.Count == 0) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(properties)}[{properties}]", DomainExceptionMessage.ExceptionType.Empty));
+      if (string.IsNullOrEmpty(name)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(name)}[{name}]", ExceptionType.Empty));
+      if (string.IsNullOrEmpty(comment)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(comment)}[{comment}]", ExceptionType.Empty));
+      if (properties.Count == 0) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(properties)}[{properties}]", ExceptionType.Empty));
       if (exceptionMessages.Count > 0) throw new DomainException(exceptionMessages.AsReadOnly());
 
       return new ClassEntity()

--- a/src/NET6/Domain/Classes/PropertyEntity.cs
+++ b/src/NET6/Domain/Classes/PropertyEntity.cs
@@ -12,19 +12,19 @@ namespace Domain.Classes
     /// 名称
     /// </summary>
     /// <value>プロパティ名</value>
-    public string Name { get; private set; }
+    public string Name { get; init; }
 
     /// <summary>
     /// 型名
     /// </summary>
     /// <value>型名称</value>
-    public string TypeName { get; private set; }
+    public string TypeName { get; init; }
 
     /// <summary>
     /// コメント
     /// </summary>
     /// <value>コメント文字列</value>
-    public string Comment { get; private set; }
+    public string Comment { get; init; }
 
     /// <summary>
     /// 非公開コンストラクタ

--- a/src/NET6/Domain/Classes/PropertyEntity.cs
+++ b/src/NET6/Domain/Classes/PropertyEntity.cs
@@ -44,9 +44,9 @@ namespace Domain.Classes
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
-      if (string.IsNullOrEmpty(name)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(name)}[{name}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (string.IsNullOrEmpty(typeName)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(typeName)}[{typeName}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (string.IsNullOrEmpty(comment)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(comment)}[{comment}]", DomainExceptionMessage.ExceptionType.Empty));
+      if (string.IsNullOrEmpty(name)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(name)}[{name}]", ExceptionType.Empty));
+      if (string.IsNullOrEmpty(typeName)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(typeName)}[{typeName}]", ExceptionType.Empty));
+      if (string.IsNullOrEmpty(comment)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(comment)}[{comment}]", ExceptionType.Empty));
       if (exceptionMessages.Count > 0) throw new DomainException(exceptionMessages.AsReadOnly());
 
       return new PropertyEntity()

--- a/src/NET6/Domain/DB/DBParameterEntity.cs
+++ b/src/NET6/Domain/DB/DBParameterEntity.cs
@@ -11,28 +11,28 @@ namespace Domain.DB
     /// <summary>
     /// サーバーホスト
     /// </summary>
-    public string HostName { get; private set; }
+    public string HostName { get; init; }
 
     /// <summary>
     ///　ユーザーID
     /// </summary>
-    public string UserID { get; private set; }
+    public string UserID { get; init; }
 
     /// <summary>
     /// パスワード
     /// </summary>
-    public string Password { get; private set; }
+    public string Password { get; init; }
 
     /// <summary>
     /// データベース名
     /// </summary>
-    public string Database { get; private set; }
+    public string Database { get; init; }
 
     /// <summary>
     /// ポート番号
     /// </summary>
     /// <value></value>
-    public int Port { get; private set; }
+    public int Port { get; init; }
 
     /// <summary>
     /// 非公開コンストラクタ

--- a/src/NET6/Domain/DB/DBParameterEntity.cs
+++ b/src/NET6/Domain/DB/DBParameterEntity.cs
@@ -54,11 +54,11 @@ namespace Domain.DB
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
-      if (string.IsNullOrEmpty(hostName)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(hostName)}[{hostName}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (string.IsNullOrEmpty(userID)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(userID)}[{userID}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (string.IsNullOrEmpty(password)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(password)}[{password}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (string.IsNullOrEmpty(database)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(database)}[{database}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (!port.HasValue) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(port)}[{port}]", DomainExceptionMessage.ExceptionType.Empty));
+      if (string.IsNullOrEmpty(hostName)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(hostName)}[{hostName}]", ExceptionType.Empty));
+      if (string.IsNullOrEmpty(userID)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(userID)}[{userID}]", ExceptionType.Empty));
+      if (string.IsNullOrEmpty(password)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(password)}[{password}]", ExceptionType.Empty));
+      if (string.IsNullOrEmpty(database)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(database)}[{database}]", ExceptionType.Empty));
+      if (!port.HasValue) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(port)}[{port}]", ExceptionType.Empty));
       if (exceptionMessages.Count > 0) throw new DomainException(exceptionMessages.AsReadOnly());
 
       return new DBParameterEntity()

--- a/src/NET6/Domain/Exceptions/DomainException.cs
+++ b/src/NET6/Domain/Exceptions/DomainException.cs
@@ -11,7 +11,7 @@ namespace Domain.Exceptions
     /// <summary>
     /// メッセージリスト
     /// </summary>
-    public ReadOnlyCollection<DomainExceptionMessage> Messages { get; private set; }
+    public ReadOnlyCollection<DomainExceptionMessage> Messages { get; init; }
 
     /// <summary>
     /// コンストラクタ

--- a/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
+++ b/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
@@ -17,19 +17,6 @@ namespace Domain.Exceptions
   public class DomainExceptionMessage
   {
     /// <summary>
-    /// 例外種別
-    /// </summary>
-    [System.Obsolete]
-    public enum ExceptionTypes
-    {
-      Empty,
-      ParameterError,
-      DBError,
-      FileOutputError
-    }
-
-
-    /// <summary>
     /// 対象項目
     /// </summary>
     public string Target { get; init; }

--- a/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
+++ b/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
@@ -20,7 +20,7 @@ namespace Domain.Exceptions
     /// 例外種別
     /// </summary>
     [System.Obsolete]
-    public enum ExceptionType
+    public enum ExceptionTypes
     {
       Empty,
       ParameterError,

--- a/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
+++ b/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
@@ -14,27 +14,7 @@ namespace Domain.Exceptions
   /// <summary>
   /// ドメインレイヤー用例外クラス メッセージクラス
   /// </summary>
-  public class DomainExceptionMessage
-  {
-    /// <summary>
-    /// 対象項目
-    /// </summary>
-    public string Target { get; init; }
-
-    /// <summary>
-    /// メッセージID
-    /// </summary>
-    public ExceptionType MessageID { get; init; }
-
-    /// <summary>
-    /// コンストラクタ
-    /// </summary>
-    /// <param name="target">対象項目</param>
-    /// <param name="messageId">メッセージID</param>
-    public DomainExceptionMessage(string target, ExceptionType messageId)
-    {
-      Target = target;
-      MessageID = messageId;
-    }
-  }
+  /// <param name="Target">対象項目</param>
+  /// <param name="MessageID">メッセージID</param>
+  public record DomainExceptionMessage(string Target, ExceptionType MessageID);
 }

--- a/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
+++ b/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
@@ -1,6 +1,17 @@
 namespace Domain.Exceptions
 {
   /// <summary>
+  /// 例外種別
+  /// </summary>
+  public enum ExceptionType
+  {
+    Empty,
+    ParameterError,
+    DBError,
+    FileOutputError
+  }
+
+  /// <summary>
   /// ドメインレイヤー用例外クラス メッセージクラス
   /// </summary>
   public class DomainExceptionMessage

--- a/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
+++ b/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
@@ -6,11 +6,6 @@ namespace Domain.Exceptions
   public class DomainExceptionMessage
   {
     /// <summary>
-    /// 区切り文字
-    /// </summary>
-    public const string Delimiter = ":";
-
-    /// <summary>
     /// 例外種別
     /// </summary>
     public enum ExceptionType

--- a/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
+++ b/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
@@ -19,6 +19,7 @@ namespace Domain.Exceptions
     /// <summary>
     /// 例外種別
     /// </summary>
+    [System.Obsolete]
     public enum ExceptionType
     {
       Empty,

--- a/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
+++ b/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
@@ -25,12 +25,12 @@ namespace Domain.Exceptions
     /// <summary>
     /// 対象項目
     /// </summary>
-    public string Target { get; private set; }
+    public string Target { get; init; }
 
     /// <summary>
     /// メッセージID
     /// </summary>
-    public ExceptionType MessageID { get; private set; }
+    public ExceptionType MessageID { get; init; }
 
     /// <summary>
     /// コンストラクタ

--- a/src/NET6/Infrastructure/CSFiles/CSFileRepository.cs
+++ b/src/NET6/Infrastructure/CSFiles/CSFileRepository.cs
@@ -26,8 +26,8 @@ namespace Infrastructure.CSFiles
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
-      if (classEntities.Count == 0) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(classEntities)}[{classEntities}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (fileDataEntity is null) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(fileDataEntity)}[{fileDataEntity}]", DomainExceptionMessage.ExceptionType.Empty));
+      if (classEntities.Count == 0) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(classEntities)}[{classEntities}]", ExceptionType.Empty));
+      if (fileDataEntity is null) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(fileDataEntity)}[{fileDataEntity}]", ExceptionType.Empty));
       if (exceptionMessages.Count > 0) throw new DomainException(exceptionMessages.AsReadOnly());
 
       var result = new List<string>();
@@ -56,7 +56,7 @@ namespace Infrastructure.CSFiles
       catch (System.Exception ex)
       {
         var messages = new List<DomainExceptionMessage>();
-        messages.Add(new DomainExceptionMessage($"{ex.Message}", DomainExceptionMessage.ExceptionType.FileOutputError));
+        messages.Add(new DomainExceptionMessage($"{ex.Message}", ExceptionType.FileOutputError));
         throw new DomainException(messages.AsReadOnly(), ex);
       }
 

--- a/src/NET6/Infrastructure/CSFiles/Templates/CreateCS.cs
+++ b/src/NET6/Infrastructure/CSFiles/Templates/CreateCS.cs
@@ -31,7 +31,7 @@ namespace Infrastructure.CSFiles.Templates
     /// <summary>
     /// namespace
     /// </summary>
-    public string NameSpace { private set; get; }
+    public string NameSpace { init; get; }
 
 
     /// <summary>
@@ -42,7 +42,7 @@ namespace Infrastructure.CSFiles.Templates
     /// <summary>
     /// スネークケースのままとするか
     /// </summary>
-    public bool UseSnakeCase { get; private set; }
+    public bool UseSnakeCase { get; init; }
 
     /// <summary>
     /// テーブル名やカラム名からC#用名称を取得

--- a/src/NET6/Infrastructure/DB/DBRepository.cs
+++ b/src/NET6/Infrastructure/DB/DBRepository.cs
@@ -45,7 +45,7 @@ namespace Infrastructure.DB
       catch (Exception exception)
       {
         var exceptionMessages = new List<DomainExceptionMessage>();
-        exceptionMessages.Add(new DomainExceptionMessage($"{connectionString}", DomainExceptionMessage.ExceptionType.DBError));
+        exceptionMessages.Add(new DomainExceptionMessage($"{connectionString}", ExceptionType.DBError));
         throw new DomainException(exceptionMessages.AsReadOnly(), exception);
       }
 

--- a/src/NET6/PostgreSQL2DTOTest/ApplicationTest/TestGenerateCSApplicationService.cs
+++ b/src/NET6/PostgreSQL2DTOTest/ApplicationTest/TestGenerateCSApplicationService.cs
@@ -38,7 +38,7 @@ namespace PostgreSQL2DTOTest.ApplicationTest
     {
       var ex = Assert.ThrowsAny<DomainException>(() => applicationService.GenerateCSFileFromDB(null));
       Assert.Single(ex.Messages);
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("inputParamModel[]", ex.Messages[0].Target);
     }
 

--- a/src/NET6/PostgreSQL2DTOTest/DomainTest/CSFiles/TestFileDataEntity.cs
+++ b/src/NET6/PostgreSQL2DTOTest/DomainTest/CSFiles/TestFileDataEntity.cs
@@ -34,10 +34,10 @@ namespace PostgreSQL2DTOTest.Domain.CSFiles
       var ex = Assert.ThrowsAny<DomainException>(() => FileDataEntity.Create(outputPath, nameSpace));
       Assert.Equal(2, ex.Messages.Count);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("outputPath[]", ex.Messages[0].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[1].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[1].MessageID);
       Assert.Equal("nameSpace[]", ex.Messages[1].Target);
     }
 
@@ -50,7 +50,7 @@ namespace PostgreSQL2DTOTest.Domain.CSFiles
       var ex = Assert.ThrowsAny<DomainException>(() => FileDataEntity.Create(outputPath, nameSpace));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("outputPath[]", ex.Messages[0].Target);
     }
 
@@ -63,7 +63,7 @@ namespace PostgreSQL2DTOTest.Domain.CSFiles
       var ex = Assert.ThrowsAny<DomainException>(() => FileDataEntity.Create(outputPath, nameSpace));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("nameSpace[]", ex.Messages[0].Target);
     }
 

--- a/src/NET6/PostgreSQL2DTOTest/DomainTest/Classes/TestClassEntity.cs
+++ b/src/NET6/PostgreSQL2DTOTest/DomainTest/Classes/TestClassEntity.cs
@@ -49,13 +49,13 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var ex = Assert.ThrowsAny<DomainException>(() => ClassEntity.Create(name, comment, properties.AsReadOnly()));
       Assert.Equal(3, ex.Messages.Count);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("name[]", ex.Messages[0].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[1].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[1].MessageID);
       Assert.Equal("comment[]", ex.Messages[1].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[2].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[2].MessageID);
       Assert.Equal($"properties[{properties.AsReadOnly()}]", ex.Messages[2].Target);
     }
 
@@ -69,7 +69,7 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var ex = Assert.ThrowsAny<DomainException>(() => ClassEntity.Create(name, comment, properties.AsReadOnly()));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("name[]", ex.Messages[0].Target);
     }
 
@@ -83,7 +83,7 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var ex = Assert.ThrowsAny<DomainException>(() => ClassEntity.Create(name, comment, properties.AsReadOnly()));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("comment[]", ex.Messages[0].Target);
     }
 
@@ -97,7 +97,7 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var ex = Assert.ThrowsAny<DomainException>(() => ClassEntity.Create(name, comment, properties.AsReadOnly()));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal($"properties[{properties.AsReadOnly()}]", ex.Messages[0].Target);
     }
 

--- a/src/NET6/PostgreSQL2DTOTest/DomainTest/Classes/TestPropertyEntity.cs
+++ b/src/NET6/PostgreSQL2DTOTest/DomainTest/Classes/TestPropertyEntity.cs
@@ -35,13 +35,13 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var ex = Assert.ThrowsAny<DomainException>(() => PropertyEntity.Create(name, typeName, comment));
       Assert.Equal(3, ex.Messages.Count);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("name[]", ex.Messages[0].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[1].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[1].MessageID);
       Assert.Equal("typeName[]", ex.Messages[1].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[2].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[2].MessageID);
       Assert.Equal("comment[]", ex.Messages[2].Target);
     }
 
@@ -55,7 +55,7 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var ex = Assert.ThrowsAny<DomainException>(() => PropertyEntity.Create(name, typeName, comment));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("name[]", ex.Messages[0].Target);
     }
 
@@ -69,7 +69,7 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var ex = Assert.ThrowsAny<DomainException>(() => PropertyEntity.Create(name, typeName, comment));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("typeName[]", ex.Messages[0].Target);
     }
 
@@ -83,7 +83,7 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var ex = Assert.ThrowsAny<DomainException>(() => PropertyEntity.Create(name, typeName, comment));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("comment[]", ex.Messages[0].Target);
     }
 

--- a/src/NET6/PostgreSQL2DTOTest/DomainTest/DB/TestDBParameterEntity.cs
+++ b/src/NET6/PostgreSQL2DTOTest/DomainTest/DB/TestDBParameterEntity.cs
@@ -37,19 +37,19 @@ namespace PostgreSQL2DTOTest.Domain.DB
       var ex = Assert.ThrowsAny<DomainException>(() => DBParameterEntity.Create(hostName, userID, password, database, port));
       Assert.Equal(5, ex.Messages.Count);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("hostName[]", ex.Messages[0].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[1].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[1].MessageID);
       Assert.Equal("userID[]", ex.Messages[1].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[2].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[2].MessageID);
       Assert.Equal("password[]", ex.Messages[2].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[3].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[3].MessageID);
       Assert.Equal("database[]", ex.Messages[3].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[4].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[4].MessageID);
       Assert.Equal("port[]", ex.Messages[4].Target);
     }
 
@@ -65,7 +65,7 @@ namespace PostgreSQL2DTOTest.Domain.DB
       var ex = Assert.ThrowsAny<DomainException>(() => DBParameterEntity.Create(hostName, userID, password, database, port));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("hostName[]", ex.Messages[0].Target);
     }
 
@@ -81,7 +81,7 @@ namespace PostgreSQL2DTOTest.Domain.DB
       var ex = Assert.ThrowsAny<DomainException>(() => DBParameterEntity.Create(hostName, userID, password, database, port));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("userID[]", ex.Messages[0].Target);
     }
 
@@ -97,7 +97,7 @@ namespace PostgreSQL2DTOTest.Domain.DB
       var ex = Assert.ThrowsAny<DomainException>(() => DBParameterEntity.Create(hostName, userID, password, database, port));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("password[]", ex.Messages[0].Target);
     }
 
@@ -113,7 +113,7 @@ namespace PostgreSQL2DTOTest.Domain.DB
       var ex = Assert.ThrowsAny<DomainException>(() => DBParameterEntity.Create(hostName, userID, password, database, port));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("database[]", ex.Messages[0].Target);
     }
 
@@ -129,7 +129,7 @@ namespace PostgreSQL2DTOTest.Domain.DB
       var ex = Assert.ThrowsAny<DomainException>(() => DBParameterEntity.Create(hostName, userID, password, database, port));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("port[]", ex.Messages[0].Target);
     }
 

--- a/src/NET6/PostgreSQL2DTOTest/Shared/MockCSFileRepository.cs
+++ b/src/NET6/PostgreSQL2DTOTest/Shared/MockCSFileRepository.cs
@@ -24,8 +24,8 @@ namespace PostgreSQL2DTOTest.Shared
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
-      if (classEntities.Count == 0) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(classEntities)}[{classEntities}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (fileDataEntity is null) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(fileDataEntity)}[{fileDataEntity}]", DomainExceptionMessage.ExceptionType.Empty));
+      if (classEntities.Count == 0) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(classEntities)}[{classEntities}]", ExceptionType.Empty));
+      if (fileDataEntity is null) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(fileDataEntity)}[{fileDataEntity}]", ExceptionType.Empty));
       if (exceptionMessages.Count > 0) throw new DomainException(exceptionMessages.AsReadOnly());
 
       var result = new List<string>();
@@ -44,7 +44,7 @@ namespace PostgreSQL2DTOTest.Shared
       catch (System.Exception ex)
       {
         var messages = new List<DomainExceptionMessage>();
-        messages.Add(new DomainExceptionMessage($"{ex.Message}", DomainExceptionMessage.ExceptionType.FileOutputError));
+        messages.Add(new DomainExceptionMessage($"{ex.Message}", ExceptionType.FileOutputError));
         throw new DomainException(messages.AsReadOnly(), ex);
       }
 

--- a/src/NET6/PostgreSQL2DTOTest/Shared/MockDBRepository.cs
+++ b/src/NET6/PostgreSQL2DTOTest/Shared/MockDBRepository.cs
@@ -39,7 +39,7 @@ namespace PostgreSQL2DTOTest.Shared
       catch (Exception exception)
       {
         var exceptionMessages = new List<DomainExceptionMessage>();
-        exceptionMessages.Add(new DomainExceptionMessage($"{connectionString}", DomainExceptionMessage.ExceptionType.DBError));
+        exceptionMessages.Add(new DomainExceptionMessage($"{connectionString}", ExceptionType.DBError));
         throw new DomainException(exceptionMessages.AsReadOnly(), exception);
       }
 


### PR DESCRIPTION
プロパティの初期化する際に「private set」していたが、
C#9.0から初期化時のみ有効な「init」が設定できるようになった。
また、単純なクラスであればRecord型で十分である。
それらを適用した。
